### PR TITLE
added: more servers to movies and tvshows v2

### DIFF
--- a/src/pages/StreamMovie.vue
+++ b/src/pages/StreamMovie.vue
@@ -64,7 +64,11 @@ export default defineComponent({
       { name: 'MultiEmbed', urlTemplate: 'https://multiembed.mov/?video_id={tmdbId}&tmdb=1' },
       { name: 'EmbedSU', urlTemplate: 'https://embed.su/embed/movie/{tmdbId}' },
       { name: 'VidLink', urlTemplate: 'https://vidlink.pro/movie/{tmdbId}' },
-      { name: 'AutoEmbed', urlTemplate: 'https://player.autoembed.cc/embed/movie/{tmdbId}' }
+      { name: 'AutoEmbed', urlTemplate: 'https://player.autoembed.cc/embed/movie/{tmdbId}' },
+      { name: 'VidFast', urlTemplate: 'https://vidfast.pro/movie/{tmdbId}' },
+      { name: '111Movies', urlTemplate: 'https://111movies.com/movie/{tmdbId}' },
+      { name: 'Vidora', urlTemplate: 'https://vidora.su/movie/{tmdbId}?parameters' },
+      { name: 'Smashy', urlTemplate: 'https://player.smashy.stream/movie/{tmdbId}?autoplay=true' }
     ];
 
     const currentEmbedUrl = computed(() => {

--- a/src/pages/StreamTVShow.vue
+++ b/src/pages/StreamTVShow.vue
@@ -99,8 +99,13 @@ export default defineComponent({
             { name: 'MultiEmbed', urlTemplate: 'https://multiembed.mov/?video_id={externalId}&tmdb=1&s={season}&e={episode}' },
             { name: 'Embed.su', urlTemplate: 'https://embed.su/embed/tv/{externalId}/{season}/{episode}' },
             { name: 'Vidlink', urlTemplate: 'https://vidlink.pro/tv/{externalId}/{season}/{episode}' },
-            { name: 'AutoEmbed', urlTemplate: 'https://player.autoembed.cc/embed/tv/{externalId}/{season}/{episode}' }
+            { name: 'AutoEmbed', urlTemplate: 'https://player.autoembed.cc/embed/tv/{externalId}/{season}/{episode}' },
+            { name: 'VidFast', urlTemplate: 'https://vidfast.pro/tv/{externalId}/{season}/{episode}' },
+            { name: '111Movies', urlTemplate: 'https://111movies.com/tv/{externalId}/{season}/{episode}' },
+            { name: 'Vidora', urlTemplate: 'https://vidora.su/tv/{externalId}/{season}/{episode}?autoplay=true' },
+            { name: 'Smashy', urlTemplate: 'https://player.smashy.stream/tv/{externalId}?s={season}&e={episode}' }
         ];
+
         const currentEmbedUrl = computed(() => {
             if (!externalId.value) return '';
 


### PR DESCRIPTION
This pull request adds new streaming options for both movies and TV shows in the `StreamMovie.vue` and `StreamTVShow.vue` components. These changes expand the available embed sources, providing users with more choices for streaming.

### Additions to streaming options:

* **Movies (`src/pages/StreamMovie.vue`)**:
  - Added `VidFast` with the URL template `https://vidfast.pro/movie/{tmdbId}`.
  - Added `111Movies` with the URL template `https://111movies.com/movie/{tmdbId}`.
  - Added `Vidora` with the URL template `https://vidora.su/movie/{tmdbId}?parameters`.
  - Added `Smashy` with the URL template `https://player.smashy.stream/movie/{tmdbId}?autoplay=true`.

* **TV Shows (`src/pages/StreamTVShow.vue`)**:
  - Added `VidFast` with the URL template `https://vidfast.pro/tv/{externalId}/{season}/{episode}`.
  - Added `111Movies` with the URL template `https://111movies.com/tv/{externalId}/{season}/{episode}`.
  - Added `Vidora` with the URL template `https://vidora.su/tv/{externalId}/{season}/{episode}?autoplay=true`.
  - Added `Smashy` with the URL template `https://player.smashy.stream/tv/{externalId}?s={season}&e={episode}`.