### PR TITLE
fixes: usability issue on back button

### DIFF
--- a/src/pages/StreamTVShow.vue
+++ b/src/pages/StreamTVShow.vue
@@ -198,7 +198,7 @@ export default defineComponent({
         };
 
         const goBack = () => {
-            router.push(`/tv-show/${showId.value}`);
+            router.push(`/tv-show/${showId.value}?season=${currentSeason.value}&episode=${currentEpisode.value}`);
         };
 
         const formatDate = (dateString: string) => {


### PR DESCRIPTION
This pull request updates the navigation behavior in the `StreamTVShow` component to include query parameters for the current season and episode when navigating back to the TV show page.

* **Navigation update in `StreamTVShow` component**:
  - Modified the `goBack` method to append `season` and `episode` query parameters to the URL when navigating back to the TV show page. (`src/pages/StreamTVShow.vue`, [src/pages/StreamTVShow.vueL201-R201](diffhunk://#diff-7830bd85792cd67d17d4c86d597fbcb7eee6e09c61cf27b972c38e302d4a62e6L201-R201))