### PR TITLE
Minor fix

### DIFF
--- a/src/utils/useWebImage.ts
+++ b/src/utils/useWebImage.ts
@@ -1,6 +1,6 @@
 import empty_movie_state from '../assets/img/empty-movie-state.png';
 import { Movie } from '../composables/useHighlights';
-import { TVShowDetails, TVShowType } from '../composables/useTvShows';
+import { TVShowDetails } from '../composables/useTvShows';
 
 const IMAGE_BASEURL = import.meta.env.VITE_IMAGE_BASE_URL;
 


### PR DESCRIPTION
This pull request includes a minor cleanup in the `src/utils/useWebImage.ts` file. It removes an unused import to streamline the code.

* [`src/utils/useWebImage.ts`](diffhunk://#diff-4fd5e99b2586695f91ad383f106ba5a01e741000c2aa9274c33276c51eae1b33L3-R3): Removed the unused `TVShowType` import from `../composables/useTvShows`.