### PR TITLE
changes: fix issue with watch party

### DIFF
--- a/src/composables/useWatchParty.ts
+++ b/src/composables/useWatchParty.ts
@@ -53,7 +53,7 @@ export async function fetchWatchPartyMovieData(movie: MovieDetails): Promise<voi
     
     const encodedTitle = encodeURIComponent(movie.title);
     
-    const url = `https://xprime.tv/primebox?name=${encodedTitle}&year=${releaseYear}&fallback_year=${fallbackYear}`;
+    const url = `https://backend.xprime.tv/primebox?name=${encodedTitle}&year=${releaseYear}&fallback_year=${fallbackYear}`;
     
     const response = await fetch(url);
     const data = await response.json();
@@ -108,7 +108,7 @@ export async function fetchWatchPartyTVShowData(
     
     const encodedTitle = encodeURIComponent(show.name);
     
-    const url = `https://xprime.tv/primebox?name=${encodedTitle}&year=${year}&fallback_year=${fallbackYear}&season=${seasonNumber}&episode=${episodeNumber}`;
+    const url = `https://backend.xprime.tvprimebox?name=${encodedTitle}&year=${year}&fallback_year=${fallbackYear}&season=${seasonNumber}&episode=${episodeNumber}`;
     
     const response = await fetch(url);
     const data = await response.json();


### PR DESCRIPTION
This pull request updates the URLs used in the `fetchWatchPartyMovieData` and `fetchWatchPartyTVShowData` functions to point to a new backend domain. These changes ensure that the data is fetched from the correct server.

URL updates:

* [`src/composables/useWatchParty.ts`](diffhunk://#diff-4acc2d6bbe06e66a8b1a39118c39eeb72dd0f87e6446f65d2e8021cace102ba7L56-R56): Updated the URL.
* [`src/composables/useWatchParty.ts`](diffhunk://#diff-4acc2d6bbe06e66a8b1a39118c39eeb72dd0f87e6446f65d2e8021cace102ba7L111-R111): Updated the URL.