### PR TITLE
Implement user search and view history

### DIFF
--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -1,0 +1,45 @@
+export interface ViewedItem {
+  id: number | string;
+  title: string;
+  image: string | null;
+  rating: number;
+  categories: number[];
+  adult: boolean;
+  type: 'movie' | 'tv';
+}
+
+import { useStorage } from '@vueuse/core';
+
+export const searchHistory = useStorage<string[]>('searchHistory', []);
+export const viewHistory = useStorage<ViewedItem[]>('viewHistory', []);
+
+export function addSearchTerm(term: string): void {
+  const value = term.trim();
+  if (!value) return;
+  const index = searchHistory.value.indexOf(value);
+  if (index !== -1) searchHistory.value.splice(index, 1);
+  searchHistory.value.unshift(value);
+  if (searchHistory.value.length > 5) {
+    searchHistory.value = searchHistory.value.slice(0, 5);
+  }
+}
+
+export function addViewedItem(item: ViewedItem): void {
+  const index = viewHistory.value.findIndex(
+    i => i.id === item.id && i.type === item.type
+  );
+  if (index !== -1) viewHistory.value.splice(index, 1);
+  viewHistory.value.unshift(item);
+  if (viewHistory.value.length > 5) {
+    viewHistory.value = viewHistory.value.slice(0, 5);
+  }
+}
+
+export function useHistory() {
+  return {
+    searchHistory,
+    viewHistory,
+    addSearchTerm,
+    addViewedItem
+  };
+}

--- a/src/containers/Hero.vue
+++ b/src/containers/Hero.vue
@@ -3,13 +3,17 @@
         <h1>{{ title }}</h1>
         <p>{{ subtitle }}</p>
         <div class="mini-search" v-if="search">
-            <form @submit.prevent="$emit('search', searchValue.trim())">
+            <form @submit.prevent="submitSearch">
                 <input
-                type="text" 
+                type="text"
                 :placeholder="searchPlaceholder"
-                 v-model="searchValue" 
+                v-model="searchValue"
+                list="recent-searches"
                 @focus="showClearButton = true"
                 />
+                <datalist id="recent-searches">
+                    <option v-for="term in searchHistory" :key="term" :value="term" />
+                </datalist>
                 <button
                     v-if="showClearButton && searchValue"
                     @click="clearInput"
@@ -26,8 +30,10 @@
 <script lang="ts">
 import { defineComponent, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
+import { searchHistory, addSearchTerm } from '../composables/useHistory';
 export default defineComponent({
     name: 'Hero',
+    emits: ['search'],
     props: {
         title: {
             type: String,
@@ -46,7 +52,7 @@ export default defineComponent({
             default: 'Search for a movie'
         }
     },
-    setup(props) {
+    setup(props, { emit }) {
         const searchValue = ref('');
         const showClearButton = ref(false);
 
@@ -59,6 +65,13 @@ export default defineComponent({
         const clearInput = () => {
             searchValue.value = '';
             showClearButton.value = false;
+        };
+
+        const submitSearch = () => {
+            const term = searchValue.value.trim();
+            if (!term) return;
+            addSearchTerm(term);
+            emit('search', term);
         };
         const route = useRoute();
         onMounted(() => {
@@ -76,6 +89,8 @@ export default defineComponent({
             showClearButton,
             // handleInput,
             clearInput,
+            submitSearch,
+            searchHistory
         }
     }
 });

--- a/src/containers/SearchWrapper.vue
+++ b/src/containers/SearchWrapper.vue
@@ -54,11 +54,25 @@
 
                     <!-- Quick Search Suggestions -->
                     <div class="quick-suggestions" :class="{ 'focused': isInputFocused }">
+                        <template v-if="searchHistory.length">
+                            <span class="suggestions-label">Recent searches:</span>
+                            <div class="suggestion-tags">
+                                <button
+                                    type="button"
+                                    v-for="recent in searchHistory"
+                                    :key="`recent-${recent}`"
+                                    @click="quickSearch(recent)"
+                                    class="suggestion-tag"
+                                >
+                                    {{ recent }}
+                                </button>
+                            </div>
+                        </template>
                         <span class="suggestions-label">Popular searches:</span>
                         <div class="suggestion-tags">
-                            <button 
+                            <button
                                 type="button"
-                                v-for="suggestion in popularSearches" 
+                                v-for="suggestion in popularSearches"
                                 :key="suggestion"
                                 @click="quickSearch(suggestion)"
                                 class="suggestion-tag"
@@ -101,6 +115,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
+import { searchHistory, addSearchTerm } from '../composables/useHistory';
 import Search from '../components/svg/outline/search.vue';
 import ChevronDoubleDown from '../components/svg/outline/chevron-double-down.vue';
 import ArrowRightLong from '../components/svg/outline/arrow-right-long.vue';
@@ -115,14 +130,17 @@ const popularSearches = [
 ];
 
 const handleSearch = () => {
-    if (searchValue.value.trim()) {
-        emit('search', searchValue.value);
+    const term = searchValue.value.trim();
+    if (term) {
+        addSearchTerm(term);
+        emit('search', term);
         searchValue.value = '';
     }
 };
 
 const quickSearch = (term: string) => {
     searchValue.value = term;
+    addSearchTerm(term);
     emit('search', term);
     searchValue.value = '';
 };

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -4,6 +4,29 @@
         <section class="remove-padding">
             <!-- Search Section -->
             <SearchWrapper @search="handleSearchGlobal" />
+
+            <!-- Recently Viewed Section -->
+            <div v-if="viewHistory.length" class="container push-up">
+                <div class="new-releases-title-wrapper">
+                    <h1>Recently Viewed</h1>
+                </div>
+                <div class="new-releases-row">
+                    <div class="column">
+                        <MovieItem
+                            v-for="item in viewHistory"
+                            :key="`view-${item.type}-${item.id}`"
+                            :size="'small'"
+                            :title="item.title"
+                            :image="item.image"
+                            :movie-id="item.id"
+                            :rating="item.rating"
+                            :categories="item.categories"
+                            :type="item.type"
+                            :adult="item.adult"
+                        />
+                    </div>
+                </div>
+            </div>
             
             <!-- Highlights Section -->
             <div class="container">
@@ -113,6 +136,7 @@ import { handleMovieClick } from '../composables/useMovies';
 import { useRouter } from 'vue-router';
 import LoadingState from '../containers/LoadingState.vue';
 import ErrorState from '../containers/ErrorState.vue';
+import { viewHistory } from '../composables/useHistory';
 
 export default defineComponent({
     name: 'Index',
@@ -164,7 +188,8 @@ export default defineComponent({
             handleSearchGlobal,
             loading,
             error,
-            retryFetch
+            retryFetch,
+            viewHistory
         }
     }
 });

--- a/src/pages/Movie.vue
+++ b/src/pages/Movie.vue
@@ -159,6 +159,7 @@ import Play from '../components/svg/solid/play.vue';
 import Video from '../components/svg/outline/video.vue';
 import Clock from '../components/svg/outline/clock.vue';
 import OpenExternal from '../components/svg/outline/open-external.vue';
+import { addViewedItem } from '../composables/useHistory';
 
 export default defineComponent({
     name: "Movie",
@@ -241,6 +242,17 @@ export default defineComponent({
                     handleFetchMovieImages(),
                     handleFetchSimilarMovies()
                 ]);
+                if (movie.value) {
+                    addViewedItem({
+                        id: movie.value.id,
+                        title: movie.value.title,
+                        image: movie.value.poster_path,
+                        rating: movie.value.vote_average,
+                        categories: movie.value.genres?.map(g => g.id) || [],
+                        adult: movie.value.adult,
+                        type: 'movie'
+                    });
+                }
             } catch (error: any) {
                 hasError.value = true;
                 errorMessage.value = error.message || 'Failed to load movie details';

--- a/src/pages/Movies.vue
+++ b/src/pages/Movies.vue
@@ -55,6 +55,7 @@ import ResultsHeader from '../components/layout/ResultsHeader.vue';
 import LoadingState from '../containers/LoadingState.vue';
 import EmptyState from '../containers/EmptyState.vue';
 import LoadMoreButton from '../components/layout/LoadMoreButton.vue';
+import { addSearchTerm } from '../composables/useHistory';
 
 export default defineComponent({
     name: 'Movies',
@@ -202,6 +203,7 @@ export default defineComponent({
 
             currentSearchTerm.value = searchValue;
             filteredGenres.value = [];
+            addSearchTerm(searchValue);
 
             const searchUrl = `https://api.themoviedb.org/3/search/movie?query=${searchValue}&language=en-US&page=1`;
             await searchMovies(searchUrl);

--- a/src/pages/Search.vue
+++ b/src/pages/Search.vue
@@ -171,6 +171,7 @@ import LoadMoreButton from '../components/layout/LoadMoreButton.vue';
 import EmptyState from '../containers/EmptyState.vue';
 import X from '../components/svg/outline/x.vue';
 import LoadingState from '../containers/LoadingState.vue';
+import { addSearchTerm } from '../composables/useHistory';
 
 const route = useRoute();
 const router = useRouter();
@@ -200,7 +201,9 @@ const handleSearch = (searchQuery: string) => {
         handleClearSearch();
         return;
     }
-    
+
+    addSearchTerm(searchQuery.trim());
+
     router.push({ query: { search: searchQuery.trim() } });
 };
 

--- a/src/pages/TVShow.vue
+++ b/src/pages/TVShow.vue
@@ -219,6 +219,7 @@ import Video from '../components/svg/outline/video.vue';
 import Clock from '../components/svg/outline/clock.vue';
 import OpenExternal from '../components/svg/outline/open-external.vue';
 import ArrowRight from '../components/svg/outline/arrow-right.vue';
+import { addViewedItem } from '../composables/useHistory';
 
 export default defineComponent({
     name: 'TVShow',
@@ -315,6 +316,17 @@ export default defineComponent({
                     handleFetchTvShowImages(),
                     handleFetchSimilarTvShows(),
                 ]);
+                if (tvShow.value) {
+                    addViewedItem({
+                        id: tvShow.value.id,
+                        title: tvShow.value.name,
+                        image: tvShow.value.poster_path,
+                        rating: tvShow.value.vote_average,
+                        categories: tvShow.value.genres?.map(g => g.id) || [],
+                        adult: (tvShow.value as any).adult || false,
+                        type: 'tv'
+                    });
+                }
             } catch (error: any) {
                 hasError.value = true;
                 errorMessage.value = error.message || 'Failed to load TV show details';

--- a/src/pages/TVShows.vue
+++ b/src/pages/TVShows.vue
@@ -54,6 +54,7 @@ import ResultsHeader from '../components/layout/ResultsHeader.vue';
 import LoadingState from '../containers/LoadingState.vue';
 import LoadMoreButton from '../components/layout/LoadMoreButton.vue';
 import EmptyState from '../containers/EmptyState.vue';
+import { addSearchTerm } from '../composables/useHistory';
 
 export default defineComponent({
     name: 'TVShows',
@@ -200,6 +201,7 @@ export default defineComponent({
 
             currentSearchTerm.value = searchValue;
             filteredGenres.value = [];
+            addSearchTerm(searchValue);
 
             const searchUrl = `https://api.themoviedb.org/3/search/tv?query=${searchValue}&language=en-US&page=1`;
             await searchTvShows(searchUrl);


### PR DESCRIPTION
## Summary
- add composable to store search terms and viewed items
- show recent searches in SearchWrapper and Hero inputs
- save search terms when searching
- save viewed items when opening movie or tv pages
- display recently viewed on home page

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad27b5bdc832d92870a60d11876d2